### PR TITLE
Fix delete profile home link: use ng app root

### DIFF
--- a/src/profile/templates/user_management/profile/delete-profile-confirmation.html
+++ b/src/profile/templates/user_management/profile/delete-profile-confirmation.html
@@ -1,6 +1,6 @@
 <div data-extend-template="templates/base.html" class="profile-page">
     <div data-block="page-body-content-inner">
         <span translate>Your account has been deleted.</span>
-         <a class="btn btn-default" ng-href="/" translate>Home</a>
+         <a class="btn btn-default" href="#/" translate>Home</a>
     </div>
 </div>


### PR DESCRIPTION
`/` will go to the server's document root, which in some cases may not be the Angular app root. `#/` has the same intention but will work with Angular apps served from subdirectories.

@incuna/frontend Please merge, ta!